### PR TITLE
log the fetch error

### DIFF
--- a/src/Players/Update.elm
+++ b/src/Players/Update.elm
@@ -34,7 +34,10 @@ update action model =
           ( players, Effects.none )
 
         Err error ->
-          ( model.players, Effects.none )
+          let
+              _ = Debug.log "fetching players error" error
+          in
+              ( model.players, Effects.none )
 
     HopAction _ ->
       ( model.players, Effects.none )


### PR DESCRIPTION
Although it does not mean handle the error this can be the first time the user meet an Http.Error. 
It would be useful to show it in the console.
